### PR TITLE
A few suggested updates

### DIFF
--- a/doc/payload-map.txt
+++ b/doc/payload-map.txt
@@ -2,21 +2,137 @@
 payload length: 659 Bytes
 
 
-offset		type	value
+offset		type	value	description
 -------------------------------------------------------
+0x007		int16		S/N prefix
+0x009		int16		S/N suffix
+0x00b		int16		Firmware version
+0x00d		int16		Bootloader version
+0x00f		int16		Hardware version
 
-0x067		int16	temp1
-0x069		int16	temp2
-0x071		int16	temp3
-0x073		int16	temp4
-0x075		int16	temp5
-0x077		int16	temp6
-0x079		int16	temp7
-0x081		int16	temp8
+0x067		int16	temp1	Internal temp sensor 1
+0x069		int16	temp2	Internal temp sensor 2
+0x06b		int16	temp3	Internal temp sensor 3
+0x06d		int16	temp4	Internal temp sensor 4
+0x06f		int16	temp5	Internal temp sensor 5
+0x071		int16	temp6	Internal temp sensor 6
+0x073		int16	temp7	Internal temp sensor 7
+0x075		int16	temp8	Internal temp sensor 8
+
+0x077		int16	temp9	External (aquabus?) temp sensor 9
+0x079		int16	temp10	External (aquabus?) temp sensor 10
+0x07b		int16	temp11	External (aquabus?) temp sensor 11 
+0x07d		int16	temp12	External (aquabus?) temp sensor 12
+0x07f		int16	temp13	External (aquabus?) temp sensor 13
+0x081		int16	temp14	External (aquabus?) temp sensor 14
+0x083		int16	temp15	External (aquabus?) temp sensor 15
+0x085		int16	temp16	External (aquabus?) temp sensor 16
+
+0x087		int16	temp17	External (aquabus?) temp sensor 17
+0x089		int16	temp18	External (aquabus?) temp sensor 18
+0x08b		int16	temp19	External (aquabus?) temp sensor 19
+0x08d		int16	temp20	External (aquabus?) temp sensor 20	
+0x08f		int16	temp21	External (aquabus?) temp sensor 21
+0x091		int16	temp22	External (aquabus?) temp sensor 22
+0x093		int16	temp23	External (aquabus?) temp sensor 23
+0x095		int16	temp24	External (aquabus?) temp sensor 24
+
+0x097		int16	temp25	External (aquabus?) temp sensor 25
+0x099		int16	temp26	External (aquabus?) temp sensor 26
+0x09b		int16	temp27	External (aquabus?) temp sensor 27
+0x09d		int16	temp28	External (aquabus?) temp sensor 28
+0x09f		int16	temp29	External (aquabus?) temp sensor 29
+0x0a1		int16	temp30	External (aquabus?) temp sensor 30
+0x0a3		int16	temp31	External (aquabus?) temp sensor 31
+0x0a5		int16	temp32	External (aquabus?) temp sensor 32
+
+0x0a7		int16	temp33	External (aquabus?) temp sensor 33
+0x0a9		int16	temp34	External (aquabus?) temp sensor 34
+0x0ab		int16	temp35	External (aquabus?) temp sensor 35
+0x0ad		int16	temp36	External (aquabus?) temp sensor 36
+0x0af		int16	temp37	External (aquabus?) temp sensor 37
+0x0b1		int16	temp38	External (aquabus?) temp sensor 38
+0x0b3		int16	temp39	External (aquabus?) temp sensor 39
+0x0b5		int16	temp40	External (aquabus?) temp sensor 40
+
+0x0b7		int16	temp41	External (aquabus?) temp sensor 41
+0x0b9		int16	temp42	External (aquabus?) temp sensor 42
+0x0bb		int16	temp43	External (aquabus?) temp sensor 43
+0x0bd		int16	temp44	External (aquabus?) temp sensor 44
+
+0x0bf		int16		Internal fan VRM temp 1
+0x0c1		int16		Internal fan VRM temp 2
+0x0c3		int16		Internal fan VRM temp 3
+0x0c5		int16		Internal fan VRM temp 4
+
+0x0c7		int16		External (aquabus?) fan VRM temp 5
+0x0c9		int16		External (aquabus?) fan VRM temp 6
+0x0cb		int16		External (aquabus?) fan VRM temp 7
+0x0cd		int16		External (aquabus?) fan VRM temp 8
+0x0cf		int16		External (aquabus?) fan VRM temp 9
+0x0d1		int16		External (aquabus?) fan VRM temp 10
+0x0d3		int16		External (aquabus?) fan VRM temp 11
+0x0d5		int16		External (aquabus?) fan VRM temp 12
 
 0x0fb		int16	flow
 
-0x169		int16	fan1 rpm
-0x171		int16	fan2 rpm
-0x179		int16	fan3 rpm
-0x181		int16	fan4 rpm
+0x167		int16			Internal fan 1 VRM current
+0x169		int16	fan1 rpm	Internal fan 1 RPM
+0x16b		int16			Internal fan 1 Duty cycle
+0x16d		int16			Internal fan 1 Voltage
+
+0x16f		int16			Internal fan 2 VRM current
+0x171		int16	fan2 rpm	Internal fan 2 RPM
+0x173		int16			Internal fan 2 Duty cycle
+0x175		int16			Internal fan 2 Voltage
+
+0x177		int16			Internal fan 3 VRM current
+0x179		int16	fan3 rpm	Internal fan 3 RPM
+0x17b		int16			Internal fan 3 Duty cycle
+0x17d		int16			Internal fan 3 Voltage
+
+0x17f		int16			Internal fan 4 VRM current
+0x181		int16	fan4 rpm	Internal fan 4 RPM
+0x183		int16			Internal fan 4 Duty cycle
+0x185		int16			Internal fan 4 Voltage
+
+0x187		int16			External (aquabus?) fan 5 VRM current
+0x189		int16	fan5 rpm	External (aquabus?) fan 5 RPM
+0x18b		int16			External (aquabus?) fan 5 Duty cycle
+0x18d		int16			External (aquabus?) fan 5 Voltage
+
+0x18f		int16			External (aquabus?) fan 6 VRM current
+0x191		int16	fan6 rpm	External (aquabus?) fan 6 RPM
+0x193		int16			External (aquabus?) fan 6 Duty cycle
+0x195		int16			External (aquabus?) fan 6 Voltage
+
+0x197		int16			External (aquabus?) fan 7 VRM current
+0x199		int16	fan7 rpm	External (aquabus?) fan 7 RPM
+0x19b		int16			External (aquabus?) fan 7 Duty cycle
+0x19d		int16			External (aquabus?) fan 7 Voltage
+
+0x19f		int16			External (aquabus?) fan 8 VRM current
+0x1a1		int16	fan8 rpm	External (aquabus?) fan 8 RPM
+0x1a3		int16			External (aquabus?) fan 8 Duty cycle
+0x1a5		int16			External (aquabus?) fan 8 Voltage
+
+0x1a7		int16			External (aquabus?) fan 9 VRM current
+0x1a9		int16	fan9 rpm	External (aquabus?) fan 9 RPM
+0x1ab		int16			External (aquabus?) fan 9 Duty cycle
+0x1ad		int16			External (aquabus?) fan 9 Voltage
+
+0x1af		int16			External (aquabus?) fan 10 VRM current
+0x1b1		int16	fan10 rpm	External (aquabus?) fan 10 RPM
+0x1b3		int16			External (aquabus?) fan 10 Duty cycle
+0x1b5		int16			External (aquabus?) fan 10 Voltage
+
+0x1b7		int16			External (aquabus?) fan 11 VRM current
+0x1b9		int16	fan11 rpm	External (aquabus?) fan 11 RPM
+0x1bb		int16			External (aquabus?) fan 11 Duty cycle
+0x1bd		int16			External (aquabus?) fan 11 Voltage
+
+0x1bf		int16			External (aquabus?) fan 12 VRM current
+0x1c1		int16	fan12 rpm	External (aquabus?) fan 12 RPM
+0x1c3		int16			External (aquabus?) fan 12 Duty cycle
+0x1c5		int16			External (aquabus?) fan 12 Voltage
+

--- a/doc/payload-map.txt
+++ b/doc/payload-map.txt
@@ -2,13 +2,13 @@
 payload length: 659 Bytes
 
 
-offset		type	value	description
+offset		type	value		description
 -------------------------------------------------------
-0x007		int16		S/N prefix
-0x009		int16		S/N suffix
-0x00b		int16		Firmware version
-0x00d		int16		Bootloader version
-0x00f		int16		Hardware version
+0x007		int16	serial_major	S/N prefix
+0x009		int16	serial_minor	S/N suffix
+0x00b		int16	firmware_version	Firmware version
+0x00d		int16	bootloader_version	Bootloader version
+0x00f		int16	hardware_version	Hardware version
 
 0x067		int16	temp1	Internal temp sensor 1
 0x069		int16	temp2	Internal temp sensor 2
@@ -60,79 +60,79 @@ offset		type	value	description
 0x0bb		int16	temp43	External (aquabus?) temp sensor 43
 0x0bd		int16	temp44	External (aquabus?) temp sensor 44
 
-0x0bf		int16		Internal fan VRM temp 1
-0x0c1		int16		Internal fan VRM temp 2
-0x0c3		int16		Internal fan VRM temp 3
-0x0c5		int16		Internal fan VRM temp 4
+0x0bf		int16	fan1 vrm_temp	Internal fan VRM temp 1
+0x0c1		int16	fan2 vrm_temp	Internal fan VRM temp 2
+0x0c3		int16	fan3 vrm_temp	Internal fan VRM temp 3
+0x0c5		int16	fan4 vrm_temp	Internal fan VRM temp 4
 
-0x0c7		int16		External (aquabus?) fan VRM temp 5
-0x0c9		int16		External (aquabus?) fan VRM temp 6
-0x0cb		int16		External (aquabus?) fan VRM temp 7
-0x0cd		int16		External (aquabus?) fan VRM temp 8
-0x0cf		int16		External (aquabus?) fan VRM temp 9
-0x0d1		int16		External (aquabus?) fan VRM temp 10
-0x0d3		int16		External (aquabus?) fan VRM temp 11
-0x0d5		int16		External (aquabus?) fan VRM temp 12
+0x0c7		int16	fan5 vrm_temp	External (aquabus?) fan VRM temp 5
+0x0c9		int16	fan6 vrm_temp	External (aquabus?) fan VRM temp 6
+0x0cb		int16	fan7 vrm_temp	External (aquabus?) fan VRM temp 7
+0x0cd		int16	fan8 vrm_temp	External (aquabus?) fan VRM temp 8
+0x0cf		int16	fan9 vrm_temp	External (aquabus?) fan VRM temp 9
+0x0d1		int16	fan10 vrm_temp	External (aquabus?) fan VRM temp 10
+0x0d3		int16	fan11 vrm_temp	External (aquabus?) fan VRM temp 11
+0x0d5		int16	fan12 vrm_temp	External (aquabus?) fan VRM temp 12
 
 0x0fb		int16	flow
 
-0x167		int16			Internal fan 1 VRM current
+0x167		int16	fan1 current	Internal fan 1 VRM current
 0x169		int16	fan1 rpm	Internal fan 1 RPM
-0x16b		int16			Internal fan 1 Duty cycle
-0x16d		int16			Internal fan 1 Voltage
+0x16b		int16	fan1 duty_cycle	Internal fan 1 Duty cycle
+0x16d		int16	fan1 voltage	Internal fan 1 Voltage
 
-0x16f		int16			Internal fan 2 VRM current
+0x16f		int16	fan2 current	Internal fan 2 VRM current
 0x171		int16	fan2 rpm	Internal fan 2 RPM
-0x173		int16			Internal fan 2 Duty cycle
-0x175		int16			Internal fan 2 Voltage
+0x173		int16	fan2 duty_cycle	Internal fan 2 Duty cycle
+0x175		int16	fan2 voltage	Internal fan 2 Voltage
 
-0x177		int16			Internal fan 3 VRM current
+0x177		int16	fan3 current	Internal fan 3 VRM current
 0x179		int16	fan3 rpm	Internal fan 3 RPM
-0x17b		int16			Internal fan 3 Duty cycle
-0x17d		int16			Internal fan 3 Voltage
+0x17b		int16	fan3 duty_cycle	Internal fan 3 Duty cycle
+0x17d		int16	fan3 voltage	Internal fan 3 Voltage
 
-0x17f		int16			Internal fan 4 VRM current
+0x17f		int16	fan4 current	Internal fan 4 VRM current
 0x181		int16	fan4 rpm	Internal fan 4 RPM
-0x183		int16			Internal fan 4 Duty cycle
-0x185		int16			Internal fan 4 Voltage
+0x183		int16	fan4 duty_cycle	Internal fan 4 Duty cycle
+0x185		int16	fan4 voltage	Internal fan 4 Voltage
 
-0x187		int16			External (aquabus?) fan 5 VRM current
+0x187		int16	fan5 current	External (aquabus?) fan 5 VRM current
 0x189		int16	fan5 rpm	External (aquabus?) fan 5 RPM
-0x18b		int16			External (aquabus?) fan 5 Duty cycle
-0x18d		int16			External (aquabus?) fan 5 Voltage
+0x18b		int16	fan5 duty_cycle	External (aquabus?) fan 5 Duty cycle
+0x18d		int16	fan5 voltage	External (aquabus?) fan 5 Voltage
 
-0x18f		int16			External (aquabus?) fan 6 VRM current
+0x18f		int16	fan6 current	External (aquabus?) fan 6 VRM current
 0x191		int16	fan6 rpm	External (aquabus?) fan 6 RPM
-0x193		int16			External (aquabus?) fan 6 Duty cycle
-0x195		int16			External (aquabus?) fan 6 Voltage
+0x193		int16	fan6 duty_cycle	External (aquabus?) fan 6 Duty cycle
+0x195		int16	fan6 voltage	External (aquabus?) fan 6 Voltage
 
-0x197		int16			External (aquabus?) fan 7 VRM current
+0x197		int16	fan7 current	External (aquabus?) fan 7 VRM current
 0x199		int16	fan7 rpm	External (aquabus?) fan 7 RPM
-0x19b		int16			External (aquabus?) fan 7 Duty cycle
-0x19d		int16			External (aquabus?) fan 7 Voltage
+0x19b		int16	fan7 duty_cycle	External (aquabus?) fan 7 Duty cycle
+0x19d		int16	fan7 voltage	External (aquabus?) fan 7 Voltage
 
-0x19f		int16			External (aquabus?) fan 8 VRM current
+0x19f		int16	fan8 current	External (aquabus?) fan 8 VRM current
 0x1a1		int16	fan8 rpm	External (aquabus?) fan 8 RPM
-0x1a3		int16			External (aquabus?) fan 8 Duty cycle
-0x1a5		int16			External (aquabus?) fan 8 Voltage
+0x1a3		int16	fan8 duty_cycle	External (aquabus?) fan 8 Duty cycle
+0x1a5		int16	fan8 voltage	External (aquabus?) fan 8 Voltage
 
-0x1a7		int16			External (aquabus?) fan 9 VRM current
+0x1a7		int16	fan9 current	External (aquabus?) fan 9 VRM current
 0x1a9		int16	fan9 rpm	External (aquabus?) fan 9 RPM
-0x1ab		int16			External (aquabus?) fan 9 Duty cycle
-0x1ad		int16			External (aquabus?) fan 9 Voltage
+0x1ab		int16	fan9 duty_cycle	External (aquabus?) fan 9 Duty cycle
+0x1ad		int16	fan9 voltage	External (aquabus?) fan 9 Voltage
 
-0x1af		int16			External (aquabus?) fan 10 VRM current
+0x1af		int16	fan10 current	External (aquabus?) fan 10 VRM current
 0x1b1		int16	fan10 rpm	External (aquabus?) fan 10 RPM
-0x1b3		int16			External (aquabus?) fan 10 Duty cycle
-0x1b5		int16			External (aquabus?) fan 10 Voltage
+0x1b3		int16	fan10 duty_cycle	External (aquabus?) fan 10 Duty cycle
+0x1b5		int16	fan10 voltage	External (aquabus?) fan 10 Voltage
 
-0x1b7		int16			External (aquabus?) fan 11 VRM current
+0x1b7		int16	fan11 current	External (aquabus?) fan 11 VRM current
 0x1b9		int16	fan11 rpm	External (aquabus?) fan 11 RPM
-0x1bb		int16			External (aquabus?) fan 11 Duty cycle
-0x1bd		int16			External (aquabus?) fan 11 Voltage
+0x1bb		int16	fan11 duty_cycle	External (aquabus?) fan 11 Duty cycle
+0x1bd		int16	fan11 voltage	External (aquabus?) fan 11 Voltage
 
-0x1bf		int16			External (aquabus?) fan 12 VRM current
+0x1bf		int16	fan12 current	External (aquabus?) fan 12 VRM current
 0x1c1		int16	fan12 rpm	External (aquabus?) fan 12 RPM
-0x1c3		int16			External (aquabus?) fan 12 Duty cycle
-0x1c5		int16			External (aquabus?) fan 12 Voltage
+0x1c3		int16	fan12 duty_cycle	External (aquabus?) fan 12 Duty cycle
+0x1c5		int16	fan12 voltage	External (aquabus?) fan 12 Voltage
 

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -48,17 +48,29 @@ int main(int argc, char *argv[])
 	} 
 
 	/* output mode changes format strings */
-	const char *temp_fstr, *fan_fstr, *flow_fstr;;
+	const char *temp_fstr, *fan_vrm_temp_fstr, *fan_current_fstr, *fan_rpm_fstr, *fan_duty_cycle_fstr, *fan_voltage_fstr, *flow_fstr;;
 
 	switch (out_mode) {
 		case M_STD:
+			printf("Serial number = %d-%d\n", aquaero_data.serial_major, aquaero_data.serial_minor);
+			printf("Firmware version = %d\n", aquaero_data.firmware_version);
+			printf("Bootloader version = %d\n", aquaero_data.bootloader_version);
+			printf("Hardware version = %d\n", aquaero_data.hardware_version);
 			temp_fstr = "temp%d: %2.2f °C\n";
-			fan_fstr = "fan%d: %d rpm\n";
+			fan_vrm_temp_fstr = "fan%d VRM temp: %2.2f °C\n";
+			fan_current_fstr = "fan%d current: %4.2f mA\n";
+			fan_rpm_fstr = "fan%d RPM: %d rpm\n";
+			fan_duty_cycle_fstr = "fan%d duty cycle: %3.2f %%\n";
+			fan_voltage_fstr = "fan%d voltage: %2.2f V\n";
 			flow_fstr = "flow: %3.1f l/h\n";
 			break;
 		case M_SCRIPT:
 			temp_fstr = "TEMP%d=%2.2f\n";
-			fan_fstr = "FAN%d_RPM=%d\n";
+			fan_vrm_temp_fstr = "FAN%d_VRM_TEMP=%2.2f\n";
+			fan_current_fstr = "FAN%d_CURRENT=%4.2f\n";
+			fan_rpm_fstr = "FAN%d_RPM=%d\n";
+			fan_duty_cycle_fstr = "FAN%d_DUTY_CYCLE=%3.2f\n";
+			fan_voltage_fstr = "FAN%d_VOLTAGE=%2.2f\n";
 			flow_fstr = "FLOW=%3.1f\n";
 			break;
 	}
@@ -70,8 +82,15 @@ int main(int argc, char *argv[])
 	}
 
 	if (1) { /* print_fan */
-		for (int n=0; n<AQ5_NUM_FAN; n++)
-			printf(fan_fstr, n+1, aquaero_data.fan_rpm[n]);
+		for (int n=0; n<AQ5_NUM_FAN; n++) {
+			if (aquaero_data.fan_vrm_temp[n] != AQ_TEMP_UNDEF) {
+				printf(fan_vrm_temp_fstr, n+1, aquaero_data.fan_vrm_temp[n]);
+				printf(fan_current_fstr, n+1, aquaero_data.fan_current[n]);
+				printf(fan_rpm_fstr, n+1, aquaero_data.fan_rpm[n]);
+				printf(fan_duty_cycle_fstr, n+1, aquaero_data.fan_duty_cycle[n]);
+				printf(fan_voltage_fstr, n+1, aquaero_data.fan_voltage[n]);
+			}
+		}
 	}
 
 	if (1) { /* print flow */

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -16,14 +16,6 @@
  * along with aerotools-ng. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "libaquaero5.h" 
-*/
 #include "aerocli5.h"
 
 
@@ -89,6 +81,7 @@ int main(int argc, char *argv[])
 	return 0;
 }
 
+/* dump_data() borrowed from original aerotools */
 int dump_data(char *file, unsigned char *buffer)
 {
 	FILE *fh;

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -16,17 +16,23 @@
  * along with aerotools-ng. If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 
-#include "libaquaero5.h"
+#include "libaquaero5.h" 
+*/
+#include "aerocli5.h"
+
 
 typedef enum { M_STD, M_SCRIPT } out_mode_t;
 
 int main(int argc, char *argv[])
 {
+	int	r = EXIT_SUCCESS;
+
 	if (argc < 2) {
 		fprintf(stderr, "%s: insufficient arguments.\n", argv[0]);
 		exit(EXIT_FAILURE);
@@ -43,6 +49,11 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "failed to poll '%s': %s\n", argv[1], strerror(errno));
 		exit(EXIT_FAILURE);
 	}
+
+	if (argc >= 3 && strcmp(argv[2], "--dump") == 0) {
+		printf("Dumping data to %s\n", argv[3]);
+		r = dump_data(argv[3], aquaero_get_buffer());
+	} 
 
 	/* output mode changes format strings */
 	const char *temp_fstr, *fan_fstr, *flow_fstr;;
@@ -76,4 +87,23 @@ int main(int argc, char *argv[])
 	}
 
 	return 0;
+}
+
+int dump_data(char *file, unsigned char *buffer)
+{
+	FILE *fh;
+	
+	if ((fh = fopen(file, "w")) == NULL) {
+		perror(file);
+		return EXIT_FAILURE;
+	}
+	if (fwrite(buffer, 1, AQ5_DATA_LEN, fh) != AQ5_DATA_LEN) {
+		perror(file);
+		fclose(fh);
+		return EXIT_FAILURE;
+	}
+
+	fclose(fh);
+
+	return EXIT_SUCCESS;
 }

--- a/src/aerocli5.h
+++ b/src/aerocli5.h
@@ -1,6 +1,6 @@
 /* Copyright 2012-2013 lynix <lynix47@gmail.com>
  *
- * This file is part of aerotools.
+ * This file is part of aerotools-ng.
  *
  * aerotools-ng is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/aerocli5.h
+++ b/src/aerocli5.h
@@ -1,6 +1,6 @@
-/* Copyright 2012 lynix <lynix47@gmail.com>
+/* Copyright 2012-2013 lynix <lynix47@gmail.com>
  *
- * This file is part of aerotools-ng.
+ * This file is part of aerotools.
  *
  * aerotools-ng is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,31 +16,20 @@
  * along with aerotools-ng. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LIBAQUAERO5_H_
-#define LIBAQUAERO5_H_
+#ifndef AEROCLI5_H_
+#define AEROCLI5_H_
 
-#include <stdint.h>
+/* includes */
+#include <stdio.h>
+#include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 
-#define AQ5_NUM_TEMP	8
-#define AQ5_NUM_FAN		4
+#include "libaquaero5.h"
 
-#define AQ_TEMP_UNDEF	-99.0
+/* program name */
+#define PROGN                           "aerocli"
 
-#define AQ5_DATA_LEN	659
+int  dump_data(char *file, unsigned char *buffer);
 
-typedef struct {
-	double		temp[AQ5_NUM_TEMP];
-	uint16_t	fan_rpm[AQ5_NUM_FAN];
-	double		flow;
-} aq5_data_t;
-
-
-int libaquaero5_poll(char *device, aq5_data_t *data_dest);
-
-/* Helpful for debugging */
-unsigned char *aquaero_get_buffer();
-
-uint32_t get_kernel_version();
-
-#endif /* LIBAQUAERO5_H_ */
+#endif /* AEROCLI5_H_ */

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -50,6 +50,13 @@ int libaquaero5_poll(char *device, aq5_data_t *data_dest)
 
 	close(fd);
 
+	/* device info */
+	data_dest->serial_major = aq5_get_int(buffer, AQ5_SERIAL_MAJ_OFFS);
+	data_dest->serial_minor = aq5_get_int(buffer, AQ5_SERIAL_MIN_OFFS);
+	data_dest->firmware_version = aq5_get_int(buffer, AQ5_FIRMWARE_VER_OFFS);
+	data_dest->bootloader_version = aq5_get_int(buffer, AQ5_BOOTLOADER_VER_OFFS);
+	data_dest->hardware_version = aq5_get_int(buffer, AQ5_HARDWARE_VER_OFFS);
+
 	/* temperature sensors */
 	int n;
 	for (int i=0; i<AQ5_NUM_TEMP; i++) {
@@ -59,8 +66,12 @@ int libaquaero5_poll(char *device, aq5_data_t *data_dest)
 
 	/* fans */
 	for (int i=0; i<AQ5_NUM_FAN; i++) {
-		data_dest->fan_rpm[i] = aq5_get_int(buffer, AQ5_FRPM_OFFS +
-				i * AQ5_FRPM_DIST);
+		n = aq5_get_int(buffer, AQ5_FAN_VRM_OFFS + i * AQ5_FAN_VRM_DIST);
+		data_dest->fan_vrm_temp[i] = n!=AQ5_FAN_VRM_UNDEF ? (double)n/100.0 : AQ_TEMP_UNDEF;
+		data_dest->fan_current[i] = (double)aq5_get_int(buffer, AQ5_FAN_OFFS + i * AQ5_FAN_DIST) / 100.0;
+		data_dest->fan_rpm[i] = aq5_get_int(buffer, AQ5_FAN_OFFS + 2 + i * AQ5_FAN_DIST);
+		data_dest->fan_duty_cycle[i] = (double)aq5_get_int(buffer, AQ5_FAN_OFFS + 4 + i * AQ5_FAN_DIST) / 100.0;
+		data_dest->fan_voltage[i] = (double)aq5_get_int(buffer, AQ5_FAN_OFFS + 6 + i * AQ5_FAN_DIST) / 100.0;
 	}
 
 	/* flow sensor */

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -18,22 +18,6 @@
 
 #include "libaquaero5.h"
 
-/* libs */
-#include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/utsname.h>
-#include <linux/version.h>
-
-/* constats */
-/* #define AQ5_DATA_LEN	659 */
-#define AQ5_TEMP_OFFS	0x067
-#define AQ5_TEMP_DIST	2
-#define AQ5_TEMP_UNDEF	0x7fff
-#define AQ5_FRPM_OFFS	0x169
-#define AQ5_FRPM_DIST	8
-#define AQ5_FLOW_OFFS	0x0fb
 
 unsigned char buffer[AQ5_DATA_LEN];
 

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -19,11 +19,15 @@
 #include "libaquaero5.h"
 
 /* libs */
+#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <linux/version.h>
 
 /* constats */
-#define AQ5_DATA_LEN	659
+/* #define AQ5_DATA_LEN	659 */
 #define AQ5_TEMP_OFFS	0x067
 #define AQ5_TEMP_DIST	2
 #define AQ5_TEMP_UNDEF	0x7fff
@@ -31,6 +35,7 @@
 #define AQ5_FRPM_DIST	8
 #define AQ5_FLOW_OFFS	0x0fb
 
+unsigned char buffer[AQ5_DATA_LEN];
 
 inline int aq5_get_int(unsigned char *buffer, short offset)
 {
@@ -40,13 +45,23 @@ inline int aq5_get_int(unsigned char *buffer, short offset)
 int libaquaero5_poll(char *device, aq5_data_t *data_dest)
 {
 	int fd = open(device, O_RDONLY);
+
 	if (fd < 0)
 		return -1;
 
-	unsigned char buffer[AQ5_DATA_LEN];
-	if (read(fd, buffer, AQ5_DATA_LEN) != AQ5_DATA_LEN) {
-		close(fd);
-		return -1;
+	/* This is needed for kernel versions < 2.6.34 */
+	if (get_kernel_version() < KERNEL_VERSION(2,6,34)) {
+		/* printf("Kernel version is < 2.6.34, chopping off the first byte\n"); */	
+		if (read(fd, buffer, AQ5_DATA_LEN + 1) != AQ5_DATA_LEN + 1) {
+			close(fd);
+			return -1;
+		}
+		memmove(buffer, buffer + 1, AQ5_DATA_LEN + 1);
+	} else {
+		if (read(fd, buffer, AQ5_DATA_LEN) != AQ5_DATA_LEN) {
+			close(fd);
+			return -1;
+		}
 	}
 
 	close(fd);
@@ -54,7 +69,7 @@ int libaquaero5_poll(char *device, aq5_data_t *data_dest)
 	/* temperature sensors */
 	int n;
 	for (int i=0; i<AQ5_NUM_TEMP; i++) {
-		n = aq5_get_int(buffer, AQ5_TEMP_OFFS +	i * AQ5_TEMP_DIST);
+		n = aq5_get_int(buffer, AQ5_TEMP_OFFS  + i * AQ5_TEMP_DIST);
 		data_dest->temp[i] = n!=AQ5_TEMP_UNDEF ? (double)n/100.0 : AQ_TEMP_UNDEF;
 	}
 
@@ -69,3 +84,32 @@ int libaquaero5_poll(char *device, aq5_data_t *data_dest)
 
 	return 0;
 }
+
+/* Get the kernel version */
+uint32_t get_kernel_version()
+{
+	struct utsname name;
+	int major, minor, release;
+	int ret;
+	static uint32_t kernel_version;
+
+	/* Check the kernel version */
+	uname(&name);
+	ret = sscanf(name.release, "%d.%d.%d", &major, &minor, &release);
+	if (ret == 3) {
+		kernel_version = major << 16 | minor << 8 | release;
+		/* printf("Kernel Version: %d\n", kernel_version); */
+		return kernel_version;
+	} else {
+		printf("Couldn't sscanf() version string %s\n", name.release);
+		return 0;
+	}
+
+}
+
+/* Return the raw buffer data */
+unsigned char *aquaero_get_buffer()
+{
+	return buffer;
+}
+

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -19,15 +19,31 @@
 #ifndef LIBAQUAERO5_H_
 #define LIBAQUAERO5_H_
 
+/* libs */
+#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <linux/version.h>
+
+/* constats */
+#define AQ5_DATA_LEN	659
+#define AQ5_TEMP_OFFS   0x067
+#define AQ5_TEMP_DIST   2
+#define AQ5_TEMP_UNDEF  0x7fff
+#define AQ5_FRPM_OFFS   0x169
+#define AQ5_FRPM_DIST   8
+#define AQ5_FLOW_OFFS   0x0fb
+
 
 #define AQ5_NUM_TEMP	8
 #define AQ5_NUM_FAN		4
 
 #define AQ_TEMP_UNDEF	-99.0
 
-#define AQ5_DATA_LEN	659
 
 typedef struct {
 	double		temp[AQ5_NUM_TEMP];

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -31,23 +31,40 @@
 
 /* constats */
 #define AQ5_DATA_LEN	659
-#define AQ5_TEMP_OFFS   0x067
-#define AQ5_TEMP_DIST   2
-#define AQ5_TEMP_UNDEF  0x7fff
-#define AQ5_FRPM_OFFS   0x169
-#define AQ5_FRPM_DIST   8
-#define AQ5_FLOW_OFFS   0x0fb
+#define AQ5_SERIAL_MAJ_OFFS	0x007
+#define AQ5_SERIAL_MIN_OFFS	0x009
+#define AQ5_FIRMWARE_VER_OFFS	0x00b
+#define AQ5_BOOTLOADER_VER_OFFS	0x00d
+#define AQ5_HARDWARE_VER_OFFS	0x00f
+#define AQ5_TEMP_OFFS	0x067
+#define AQ5_TEMP_DIST	2
+#define AQ5_TEMP_UNDEF	0x7fff
+#define AQ5_FAN_OFFS	0x167
+#define AQ5_FAN_DIST	8
+#define AQ5_FAN_VRM_OFFS	0x0bf
+#define AQ5_FAN_VRM_DIST	2
+#define AQ5_FAN_VRM_UNDEF	0x7fff
+
+#define AQ5_FLOW_OFFS	0x0fb
 
 
-#define AQ5_NUM_TEMP	8
-#define AQ5_NUM_FAN		4
+#define AQ5_NUM_TEMP	44
+#define AQ5_NUM_FAN	12
 
 #define AQ_TEMP_UNDEF	-99.0
 
-
 typedef struct {
+	uint16_t	serial_major;
+	uint16_t	serial_minor;
+	uint16_t	firmware_version;
+	uint16_t	bootloader_version;
+	uint16_t	hardware_version;
 	double		temp[AQ5_NUM_TEMP];
+	double		fan_current[AQ5_NUM_FAN];
 	uint16_t	fan_rpm[AQ5_NUM_FAN];
+	double		fan_duty_cycle[AQ5_NUM_FAN];
+	double		fan_voltage[AQ5_NUM_FAN];
+	double		fan_vrm_temp[AQ5_NUM_FAN];
 	double		flow;
 } aq5_data_t;
 


### PR DESCRIPTION
Hi lynix, 

I put in a few changes that you might be interested in:
- Added the the ability to dump the memory payload to a file via the --dump command (code borrowed from the original aerotools)
- Added support for kernels < 2.6.34 with the hidraw bug that adds an extra byte to the beginning of the payload.
- Updated doc/payload-map.txt with device info and additional fan info offsets.
- Added support for device info
  - serial number (major-minor)
  - firmware version
  - bootloader version
  - hardware version
- Added support for additional fan info
  - VRM temp
  - current
  - duty cycle
  - voltage
