### PR TITLE
Added support for data source and control mode fan settings

### DIFF
--- a/doc/payload-map.txt
+++ b/doc/payload-map.txt
@@ -190,8 +190,8 @@ offset		type	value		description
 0x214		int16			Internal fan 1 Startboost duty cycle
 0x216		int16			Internal fan 1 Startboost duration
 0x218		int16			Internal fan 1 Pulses per revolution
-0x21a		int16			Internal fan 1 ?
-0x21c		int16			Internal fan 1 ?
+0x21a		int16			Internal fan 1 Control mode
+0x21c		int16			Internal fan 1 Data source
 0x21e		int16			Internal fan 1 Programmable fuse setting in mA
 
 0x220		int16			Internal fan 2 Min RPM
@@ -201,8 +201,8 @@ offset		type	value		description
 0x228		int16			Internal fan 2 Startboost duty cycle
 0x22a		int16			Internal fan 2 Startboost duration
 0x22c		int16			Internal fan 2 Pulses per revolution
-0x22e		int16			Internal fan 2 ?
-0x230		int16			Internal fan 2 ?
+0x22e		int16			Internal fan 2 Control mode
+0x230		int16			Internal fan 2 Data source
 0x232		int16			Internal fan 2 Programmable fuse setting in mA
 
 0x234		int16			Internal fan 3 Min RPM
@@ -212,8 +212,8 @@ offset		type	value		description
 0x23c		int16			Internal fan 3 Startboost duty cycle
 0x23e		int16			Internal fan 3 Startboost duration
 0x240		int16			Internal fan 3 Pulses per revolution
-0x242		int16			Internal fan 3 ?
-0x244		int16			Internal fan 3 ?
+0x242		int16			Internal fan 3 Control mode
+0x244		int16			Internal fan 3 Data source
 0x246		int16			Internal fan 3 Programmable fuse setting in mA
 
 0x248		int16			Internal fan 4 Min RPM
@@ -223,8 +223,8 @@ offset		type	value		description
 0x250		int16			Internal fan 4 Startboost duty cycle
 0x252		int16			Internal fan 4 Startboost duration
 0x254		int16			Internal fan 4 Pulses per revolution
-0x256		int16			Internal fan 4 ?
-0x258		int16			Internal fan 4 ?
+0x256		int16			Internal fan 4 Control mode
+0x258		int16			Internal fan 4 Data source
 0x25a		int16			Internal fan 4 Programmable fuse setting in mA
 
 0x25c		int16			External (aquabus) fan 5 Min RPM
@@ -234,8 +234,8 @@ offset		type	value		description
 0x264		int16			External (aquabus) fan 5 Startboost duty cycle
 0x266		int16			External (aquabus) fan 5 Startboost duration
 0x268		int16			External (aquabus) fan 5 Pulses per revolution
-0x26a		int16			External (aquabus) fan 5 ?
-0x26c		int16			External (aquabus) fan 5 ?
+0x26a		int16			External (aquabus) fan 5 Control mode
+0x26c		int16			External (aquabus) fan 5 Data source
 0x26e		int16			External (aquabus) fan 5 Programmable fuse setting in mA
 
 0x25c		int16			External (aquabus) fan 6 Min RPM
@@ -245,8 +245,8 @@ offset		type	value		description
 0x264		int16			External (aquabus) fan 6 Startboost duty cycle
 0x266		int16			External (aquabus) fan 6 Startboost duration
 0x268		int16			External (aquabus) fan 6 Pulses per revolution
-0x26a		int16			External (aquabus) fan 6 ?
-0x26c		int16			External (aquabus) fan 6 ?
+0x26a		int16			External (aquabus) fan 6 Control mode
+0x26c		int16			External (aquabus) fan 6 Data source
 0x26e		int16			External (aquabus) fan 6 Programmable fuse setting in mA
 
 0x270		int16			External (aquabus) fan 7 Min RPM
@@ -256,8 +256,8 @@ offset		type	value		description
 0x278		int16			External (aquabus) fan 7 Startboost duty cycle
 0x27a		int16			External (aquabus) fan 7 Startboost duration
 0x27c		int16			External (aquabus) fan 7 Pulses per revolution
-0x27e		int16			External (aquabus) fan 7 ?
-0x280		int16			External (aquabus) fan 7 ?
+0x27e		int16			External (aquabus) fan 7 Control mode
+0x280		int16			External (aquabus) fan 7 Data source
 0x282		int16			External (aquabus) fan 7 Programmable fuse setting in mA
 
 0x284		int16			External (aquabus) fan 8 Min RPM
@@ -267,8 +267,8 @@ offset		type	value		description
 0x28c		int16			External (aquabus) fan 8 Startboost duty cycle
 0x28e		int16			External (aquabus) fan 8 Startboost duration
 0x290		int16			External (aquabus) fan 8 Pulses per revolution
-0x292		int16			External (aquabus) fan 8 ?
-0x294		int16			External (aquabus) fan 8 ?
+0x292		int16			External (aquabus) fan 8 Control mode
+0x294		int16			External (aquabus) fan 8 Data source
 0x296		int16			External (aquabus) fan 8 Programmable fuse setting in mA
 
 0x298		int16			External (aquabus) fan 9 Min RPM
@@ -278,8 +278,8 @@ offset		type	value		description
 0x2a0		int16			External (aquabus) fan 9 Startboost duty cycle
 0x2a2		int16			External (aquabus) fan 9 Startboost duration
 0x2a4		int16			External (aquabus) fan 9 Pulses per revolution
-0x2a6		int16			External (aquabus) fan 9 ?
-0x2a8		int16			External (aquabus) fan 9 ?
+0x2a6		int16			External (aquabus) fan 9 Control mode
+0x2a8		int16			External (aquabus) fan 9 Data source
 0x2aa		int16			External (aquabus) fan 9 Programmable fuse setting in mA
 
 0x2ac		int16			External (aquabus) fan 10 Min RPM
@@ -289,8 +289,8 @@ offset		type	value		description
 0x2b4		int16			External (aquabus) fan 10 Startboost duty cycle
 0x2b6		int16			External (aquabus) fan 10 Startboost duration
 0x2b8		int16			External (aquabus) fan 10 Pulses per revolution
-0x2ba		int16			External (aquabus) fan 10 ?
-0x2bc		int16			External (aquabus) fan 10 ?
+0x2ba		int16			External (aquabus) fan 10 Control mode
+0x2bc		int16			External (aquabus) fan 10 Data source
 0x2be		int16			External (aquabus) fan 10 Programmable fuse setting in mA
 
 0x2c0		int16			External (aquabus) fan 11 Min RPM
@@ -300,8 +300,8 @@ offset		type	value		description
 0x2c8		int16			External (aquabus) fan 11 Startboost duty cycle
 0x2ca		int16			External (aquabus) fan 11 Startboost duration
 0x2cc		int16			External (aquabus) fan 11 Pulses per revolution
-0x2ce		int16			External (aquabus) fan 11 ?
-0x2d0		int16			External (aquabus) fan 11 ?
+0x2ce		int16			External (aquabus) fan 11 Control mode
+0x2d0		int16			External (aquabus) fan 11 Data source
 0x2d2		int16			External (aquabus) fan 11 Programmable fuse setting in mA
 
 0x2c0		int16			External (aquabus) fan 12 Min RPM
@@ -311,7 +311,7 @@ offset		type	value		description
 0x2c8		int16			External (aquabus) fan 12 Startboost duty cycle
 0x2ca		int16			External (aquabus) fan 12 Startboost duration
 0x2cc		int16			External (aquabus) fan 12 Pulses per revolution
-0x2ce		int16			External (aquabus) fan 12 ?
-0x2d0		int16			External (aquabus) fan 12 ?
+0x2ce		int16			External (aquabus) fan 12 Control mode
+0x2d0		int16			External (aquabus) fan 12 Data source
 0x2d2		int16			External (aquabus) fan 12 Programmable fuse setting in mA
 

--- a/doc/payload-map.txt
+++ b/doc/payload-map.txt
@@ -183,6 +183,80 @@ payload length: 2427 Bytes
 
 offset		type	value		description
 -------------------------------------------------------
+0x0dc		int16	temp1 offset	Internal temp sensor 1 offset
+0x0de		int16	temp2 offset	Internal temp sensor 2 offset
+0x0e0		int16	temp3 offset	Internal temp sensor 3 offset
+0x0e2		int16	temp4 offset	Internal temp sensor 4 offset
+0x0e4		int16	temp5 offset	Internal temp sensor 5 offset
+0x0e6		int16	temp6 offset	Internal temp sensor 6 offset
+0x0e8		int16	temp7 offset	Internal temp sensor 7 offset
+0x0ea		int16	temp8 offset	Internal temp sensor 8 offset
+
+0x0ec		int16	temp9 offset	External (aquabus) temp sensor 9 offset
+0x0ee		int16	temp10 offset	External (aquabus) temp sensor 10 offset
+0x0f0		int16	temp11 offset	External (aquabus) temp sensor 11 offset
+0x0f2		int16	temp12 offset	External (aquabus) temp sensor 12 offset
+0x0f4		int16	temp13 offset	External (aquabus) temp sensor 13 offset
+0x0f6		int16	temp14 offset	External (aquabus) temp sensor 14 offset
+0x0f8		int16	temp15 offset	External (aquabus) temp sensor 15 offset
+0x0fa		int16	temp16 offset	External (aquabus) temp sensor 16 offset
+
+0x0fc		int16	temp17 offset	Software temp sensor 1 (17) offset
+0x0fe		int16	temp18 offset	Software temp sensor 2 (18) offset
+0x100		int16	temp19 offset	Software temp sensor 3 (19) offset
+0x102		int16	temp20 offset	Software temp sensor 4 (20) offset
+0x104		int16	temp21 offset	Software temp sensor 5 (21) offset
+0x106		int16	temp22 offset	Software temp sensor 6 (22) offset
+0x108		int16	temp23 offset	Software temp sensor 7 (23) offset
+0x10a		int16	temp24 offset	Software temp sensor 8 (24) offset
+
+0x10c		int16	temp25 offset	Virtual temp sensor 1 (25) offset
+0x10e		int16	temp26 offset	Virtual temp sensor 2 (26) offset
+0x110		int16	temp27 offset	Virtual temp sensor 3 (27) offset
+0x112		int16	temp28 offset	Virtual temp sensor 4 (28) offset
+0x114		int16	temp29 offset	External (aquabus?) temp sensor 29 offset
+0x116		int16	temp30 offset	External (aquabus?) temp sensor 30 offset
+0x118		int16	temp31 offset	External (aquabus?) temp sensor 31 offset
+0x11a		int16	temp32 offset	External (aquabus?) temp sensor 32 offset
+
+0x11c		int16	temp33 offset	External (aquabus?) temp sensor 33 offset
+0x11e		int16	temp34 offset	External (aquabus?) temp sensor 34 offset
+0x120		int16	temp35 offset	External (aquabus?) temp sensor 35 offset
+0x122		int16	temp36 offset	External (aquabus?) temp sensor 36 offset
+0x124		int16	temp37 offset	External (aquabus?) temp sensor 37 offset
+0x126		int16	temp38 offset	External (aquabus?) temp sensor 38 offset
+0x128		int16	temp39 offset	External (aquabus?) temp sensor 39 offset
+0x12a		int16	temp40 offset	External (aquabus?) temp sensor 40 offset
+
+0x12c		int16	temp41 offset	External (aquabus?) temp sensor 41 offset
+0x12e		int16	temp42 offset	External (aquabus?) temp sensor 42 offset
+0x130		int16	temp43 offset	External (aquabus?) temp sensor 43 offset
+0x132		int16	temp44 offset	External (aquabus?) temp sensor 44 offset
+
+0x134		int16	fan1 vrm_temp offset	Internal fan VRM temp 1 offset
+0x136		int16	fan2 vrm_temp offset	Internal fan VRM temp 2 offset
+0x138		int16	fan3 vrm_temp offset	Internal fan VRM temp 3 offset
+0x13a		int16	fan4 vrm_temp offset	Internal fan VRM temp 4 offset
+
+0x13c		int16	fan5 vrm_temp offset	External (aquabus) fan VRM temp 5 offset
+0x13e		int16	fan6 vrm_temp offset	External (aquabus) fan VRM temp 6 offset
+0x140		int16	fan7 vrm_temp offset	External (aquabus) fan VRM temp 7 offset
+0x142		int16	fan8 vrm_temp offset	External (aquabus) fan VRM temp 8 offset
+0x144		int16	fan9 vrm_temp offset	External (aquabus) fan VRM temp 9 offset
+0x146		int16	fan10 vrm_temp offset	External (aquabus) fan VRM temp 10 offset
+0x148		int16	fan11 vrm_temp offset	External (aquabus) fan VRM temp 11 offset
+0x14a		int16	fan12 vrm_temp offset	External (aquabus) fan VRM temp 12 offset
+
+0x14c		int16	cpu1_temp offset	Internal CPU temp1 offset 
+0x14e		int16	cpu2_temp offset	External CPU temp2 offset?
+0x150		int16	cpu3_temp offset	External CPU temp3 offset?
+0x152		int16	cpu4_temp offset	External CPU temp4 offset? 
+0x154		int16	cpu5_temp offset	External CPU temp5 offset? 
+0x156		int16	cpu6_temp offset	External CPU temp6 offset? 
+0x158		int16	cpu7_temp offset	External CPU temp7 offset? 
+0x15a		int16	cpu8_temp offset	External CPU temp8 offset? 
+
+
 0x20c		int16			Internal fan 1 Min RPM
 0x20e		int16			Internal fan 1 Max RPM
 0x210		int16			Internal fan 1 Min duty cycle

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -205,7 +205,6 @@ int main(int argc, char *argv[])
 			settings_fan_control_use_fuse_fstr = "fan%d use programmable fuse: %d\n";
 			settings_fan_control_hold_min_power_fstr = "fan%d hold minimum power: %d\n";
 			settings_fan_data_source_fstr = "fan%d data source: %s\n";
-			/* settings_fan_data_source_fstr = "fan%d data source: 0x%x\n"; */
 			settings_fan_programmable_fuse_fstr = "fan%d programmable fuse: %d mA\n";
 			break;
 		case M_SCRIPT:
@@ -275,7 +274,6 @@ int main(int argc, char *argv[])
 			printf(settings_fan_control_use_startboost_fstr, n+1, aquaero_settings.fan_control_mode[n].use_startboost);
 			printf(settings_fan_control_use_fuse_fstr, n+1, aquaero_settings.fan_control_mode[n].use_programmable_fuse);
 			printf(settings_fan_control_hold_min_power_fstr, n+1, aquaero_settings.fan_control_mode[n].hold_minimum_power);
-			/* printf(settings_fan_data_source_fstr, n+1, aquaero_settings.fan_data_source[n]); */
 			printf(settings_fan_data_source_fstr, n+1, aq5_get_fan_data_source_string(aquaero_settings.fan_data_source[n]));
 			printf(settings_fan_programmable_fuse_fstr, n+1, aquaero_settings.fan_programmable_fuse[n]);
 		}

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* output mode changes format strings */
-	const char *temp_fstr, *fan_vrm_temp_fstr, *fan_current_fstr, *fan_rpm_fstr, *fan_duty_cycle_fstr, *fan_voltage_fstr, *flow_fstr, *cpu_temp_fstr, *level_fstr, *settings_fan_min_rpm_fstr, *settings_fan_max_rpm_fstr, *settings_fan_min_duty_cycle_fstr, *settings_fan_max_duty_cycle_fstr, *settings_fan_startboost_duty_cycle_fstr, *settings_fan_startboost_duration_fstr, *settings_fan_pulses_per_revolution_fstr, *settings_fan_programmable_fuse_fstr, *settings_fan_data_source_fstr, *settings_fan_control_regulation_mode_fstr, *settings_fan_control_use_startboost_fstr, *settings_fan_control_use_fuse_fstr, *settings_fan_control_hold_min_power_fstr;;
+	const char *temp_fstr, *fan_vrm_temp_fstr, *fan_current_fstr, *fan_rpm_fstr, *fan_duty_cycle_fstr, *fan_voltage_fstr, *flow_fstr, *cpu_temp_fstr, *level_fstr, *settings_fan_min_rpm_fstr, *settings_fan_max_rpm_fstr, *settings_fan_min_duty_cycle_fstr, *settings_fan_max_duty_cycle_fstr, *settings_fan_startboost_duty_cycle_fstr, *settings_fan_startboost_duration_fstr, *settings_fan_pulses_per_revolution_fstr, *settings_fan_programmable_fuse_fstr, *settings_fan_data_source_fstr, *settings_fan_control_regulation_mode_fstr, *settings_fan_control_use_startboost_fstr, *settings_fan_control_use_fuse_fstr, *settings_fan_control_hold_min_power_fstr, *settings_temp_offset_fstr, *settings_fan_vrm_temp_offset_fstr, *settings_cpu_temp_offset_fstr;;
 
 	struct tm aq_time, *local_aq_time, *systime;
 	time_t aq_time_t, systime_t;
@@ -206,6 +206,9 @@ int main(int argc, char *argv[])
 			settings_fan_control_hold_min_power_fstr = "fan%d hold minimum power: %d\n";
 			settings_fan_data_source_fstr = "fan%d data source: %s\n";
 			settings_fan_programmable_fuse_fstr = "fan%d programmable fuse: %d mA\n";
+			settings_temp_offset_fstr = "temp%d offset: %.2f K\n";
+			settings_fan_vrm_temp_offset_fstr = "fan%d VRM temp offset: %.2f K\n";
+			settings_cpu_temp_offset_fstr = "cpu%d temp offset: %.2f K\n";
 			break;
 		case M_SCRIPT:
 		default:
@@ -261,8 +264,13 @@ int main(int argc, char *argv[])
 	/* print settings */
 	if (out_mode != M_SCRIPT) {
 		printf("\n------Settings------\n");
+
+		for (int n=0; n<AQ5_NUM_TEMP; n++)
+			if (aquaero_data.temp[n] != AQ5_FLOAT_UNDEF)
+				printf(settings_temp_offset_fstr, n+1, aquaero_settings.temp_offset[n]);
 	
 		for (int n=0; n<AQ5_NUM_FAN; n++) {
+			printf(settings_fan_vrm_temp_offset_fstr, n+1, aquaero_settings.fan_vrm_temp_offset[n]);
 			printf(settings_fan_min_rpm_fstr, n+1, aquaero_settings.fan_min_rpm[n]);
 			printf(settings_fan_max_rpm_fstr, n+1, aquaero_settings.fan_max_rpm[n]);
 			printf(settings_fan_min_duty_cycle_fstr, n+1, aquaero_settings.fan_min_duty_cycle[n]);
@@ -277,6 +285,12 @@ int main(int argc, char *argv[])
 			printf(settings_fan_data_source_fstr, n+1, aq5_get_fan_data_source_string(aquaero_settings.fan_data_source[n]));
 			printf(settings_fan_programmable_fuse_fstr, n+1, aquaero_settings.fan_programmable_fuse[n]);
 		}
+
+		for (int n=0; n<AQ5_NUM_CPU; n++) {
+			if (aquaero_data.cpu_temp[n] != AQ5_FLOAT_UNDEF)
+				printf(settings_cpu_temp_offset_fstr, n+1, aquaero_settings.cpu_temp_offset[n]);
+		}
+
 	}
 
 	/* Shut down communications and clean up */

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 			printf(settings_fan_control_use_startboost_fstr, n+1, aquaero_settings.fan_control_mode[n].use_startboost);
 			printf(settings_fan_control_use_fuse_fstr, n+1, aquaero_settings.fan_control_mode[n].use_programmable_fuse);
 			printf(settings_fan_control_hold_min_power_fstr, n+1, aquaero_settings.fan_control_mode[n].hold_minimum_power);
-			printf(settings_fan_data_source_fstr, n+1, aq5_get_fan_data_source_string(aquaero_settings.fan_data_source[n]));
+			printf(settings_fan_data_source_fstr, n+1, libaquaero5_get_fan_data_source_string(aquaero_settings.fan_data_source[n]));
 			printf(settings_fan_programmable_fuse_fstr, n+1, aquaero_settings.fan_programmable_fuse[n]);
 		}
 

--- a/src/aerocli.c
+++ b/src/aerocli.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* output mode changes format strings */
-	const char *temp_fstr, *fan_vrm_temp_fstr, *fan_current_fstr, *fan_rpm_fstr, *fan_duty_cycle_fstr, *fan_voltage_fstr, *flow_fstr, *cpu_temp_fstr, *level_fstr, *settings_fan_min_rpm_fstr, *settings_fan_max_rpm_fstr, *settings_fan_min_duty_cycle_fstr, *settings_fan_max_duty_cycle_fstr, *settings_fan_startboost_duty_cycle_fstr, *settings_fan_startboost_duration_fstr, *settings_fan_pulses_per_revolution_fstr, *settings_fan_programmable_fuse_fstr;;
+	const char *temp_fstr, *fan_vrm_temp_fstr, *fan_current_fstr, *fan_rpm_fstr, *fan_duty_cycle_fstr, *fan_voltage_fstr, *flow_fstr, *cpu_temp_fstr, *level_fstr, *settings_fan_min_rpm_fstr, *settings_fan_max_rpm_fstr, *settings_fan_min_duty_cycle_fstr, *settings_fan_max_duty_cycle_fstr, *settings_fan_startboost_duty_cycle_fstr, *settings_fan_startboost_duration_fstr, *settings_fan_pulses_per_revolution_fstr, *settings_fan_programmable_fuse_fstr, *settings_fan_data_source_fstr, *settings_fan_control_regulation_mode_fstr, *settings_fan_control_use_startboost_fstr, *settings_fan_control_use_fuse_fstr, *settings_fan_control_hold_min_power_fstr;;
 
 	struct tm aq_time, *local_aq_time, *systime;
 	time_t aq_time_t, systime_t;
@@ -200,6 +200,12 @@ int main(int argc, char *argv[])
 			settings_fan_startboost_duty_cycle_fstr = "fan%d startboost duty cycle: %.2f %%\n";
 			settings_fan_startboost_duration_fstr = "fan%d startboost duration: %d seconds\n";
 			settings_fan_pulses_per_revolution_fstr = "fan%d pulses per revolution: %d\n";
+			settings_fan_control_regulation_mode_fstr = "fan%d regulation mode: %d\n";
+			settings_fan_control_use_startboost_fstr = "fan%d use startboost: %d\n";
+			settings_fan_control_use_fuse_fstr = "fan%d use programmable fuse: %d\n";
+			settings_fan_control_hold_min_power_fstr = "fan%d hold minimum power: %d\n";
+			settings_fan_data_source_fstr = "fan%d data source: %s\n";
+			/* settings_fan_data_source_fstr = "fan%d data source: 0x%x\n"; */
 			settings_fan_programmable_fuse_fstr = "fan%d programmable fuse: %d mA\n";
 			break;
 		case M_SCRIPT:
@@ -265,6 +271,12 @@ int main(int argc, char *argv[])
 			printf(settings_fan_startboost_duty_cycle_fstr, n+1, aquaero_settings.fan_startboost_duty_cycle[n]);
 			printf(settings_fan_startboost_duration_fstr, n+1, aquaero_settings.fan_startboost_duration[n]);
 			printf(settings_fan_pulses_per_revolution_fstr, n+1, aquaero_settings.fan_pulses_per_revolution[n]);
+			printf(settings_fan_control_regulation_mode_fstr, n+1, aquaero_settings.fan_control_mode[n].fan_regulation_mode);
+			printf(settings_fan_control_use_startboost_fstr, n+1, aquaero_settings.fan_control_mode[n].use_startboost);
+			printf(settings_fan_control_use_fuse_fstr, n+1, aquaero_settings.fan_control_mode[n].use_programmable_fuse);
+			printf(settings_fan_control_hold_min_power_fstr, n+1, aquaero_settings.fan_control_mode[n].hold_minimum_power);
+			/* printf(settings_fan_data_source_fstr, n+1, aquaero_settings.fan_data_source[n]); */
+			printf(settings_fan_data_source_fstr, n+1, aq5_get_fan_data_source_string(aquaero_settings.fan_data_source[n]));
 			printf(settings_fan_programmable_fuse_fstr, n+1, aquaero_settings.fan_programmable_fuse[n]);
 		}
 	}

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -65,6 +65,13 @@
 #define AQ5_SETTINGS_FAN_OFFS	0x20d
 #define AQ5_SETTINGS_FAN_DIST	20
 
+/* Fan settings control mode masks */
+#define AQ5_SETTINGS_CTRL_MODE_REG_MODE_OUTPUT	0x0000	
+#define AQ5_SETTINGS_CTRL_MODE_REG_MODE_RPM	0x0001
+#define AQ5_SETTINGS_CTRL_MODE_PROG_FUSE	0x0200
+#define AQ5_SETTINGS_CTRL_MODE_STARTBOOST	0x0400
+#define AQ5_SETTINGS_CTRL_MODE_HOLD_MIN_POWER	0x0100
+
 /* device-specific globals */
 /* TODO: vectorize to handle more than one device */
 unsigned char aq5_buf_data[AQ5_DATA_LEN];

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -64,6 +64,9 @@
 #define AQ5_SETTINGS_LEN		2428
 #define AQ5_SETTINGS_FAN_OFFS	0x20d
 #define AQ5_SETTINGS_FAN_DIST	20
+#define AQ5_SETTINGS_TEMP_OFFS_OFFS	0x0dc
+#define AQ5_SETTINGS_VRM_TEMP_OFFS_OFFS	0x134
+#define AQ5_SETTINGS_CPU_TEMP_OFFS_OFFS	0x14c
 
 /* Fan settings control mode masks */
 #define AQ5_SETTINGS_CTRL_MODE_REG_MODE_OUTPUT	0x0000	
@@ -350,6 +353,18 @@ int libaquaero5_getsettings(char *device, aq5_settings_t *settings_dest, char **
 		libaquaero5_exit();
 		printf("failed to get report!");
 		return -1;	
+	}
+
+	for (int i=0; i<AQ5_NUM_TEMP; i++) {
+		settings_dest->temp_offset[i] = (double)aq5_get_int(aq5_buf_settings, AQ5_SETTINGS_TEMP_OFFS_OFFS + i * AQ5_TEMP_DIST) /100.0;
+	}
+	
+	for (int i=0; i<AQ5_NUM_FAN; i++) {
+		settings_dest->fan_vrm_temp_offset[i] = (double)aq5_get_int(aq5_buf_settings, AQ5_SETTINGS_VRM_TEMP_OFFS_OFFS + i * AQ5_TEMP_DIST) /100.0;
+	}
+
+	for (int i=0; i<AQ5_NUM_CPU; i++) {
+		settings_dest->cpu_temp_offset[i] = (double)aq5_get_int(aq5_buf_settings, AQ5_SETTINGS_CPU_TEMP_OFFS_OFFS + i * AQ5_TEMP_DIST) /100.0;
 	}
 
 	/* fan settings */

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -180,14 +180,14 @@ char *aq5_strcat(char *str1, char *str2)
 
 char *aq5_get_fan_data_source_string(int id) 
 {
-	int n = (sizeof(fan_data_source_strings)/sizeof(fan_data_source_strings[0])) - 1;
+	int i;
 	/* We have to search for it */
-	for (int i=0; i <= n; i++) {
+	for (i=0; fan_data_source_strings[i].val != -1; i++) {
 		if (id == fan_data_source_strings[i].val) {
-			return (fan_data_source_strings[i].source_str);
+			break;
 		}
 	}
-	return 0;
+	return (fan_data_source_strings[i].source_str);
 }
 
 int aq5_open(char *device, char **err_msg)

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -78,6 +78,79 @@ unsigned char aq5_buf_data[AQ5_DATA_LEN];
 unsigned char aq5_buf_settings[AQ5_SETTINGS_LEN];
 int aq5_fd = -1;
 
+/* Fan data source strings */
+struct FAN_DATA_SOURCE_STRINGS {
+	fan_data_source_t	val;
+        char	*source_str;
+} fan_data_source_strings[] = {
+	{ NONE,			"No data source" },
+	{ TARGET_VAL_CONT_1,	"Target value controller 1" },
+	{ TARGET_VAL_CONT_2,	"Target value controller 2" },
+	{ TARGET_VAL_CONT_3,	"Target value controller 3" },
+	{ TARGET_VAL_CONT_4,	"Target value controller 4" },
+	{ TARGET_VAL_CONT_5,	"Target value controller 5" },
+	{ TARGET_VAL_CONT_6,	"Target value controller 6" },
+	{ TARGET_VAL_CONT_7,	"Target value controller 7" },
+	{ TARGET_VAL_CONT_8,	"Target value controller 8" },
+	{ TWO_POINT_CONT_1,	"Two point controller 1" },
+	{ TWO_POINT_CONT_2,	"Two point controller 2" },
+	{ TWO_POINT_CONT_3,	"Two point controller 3" },
+	{ TWO_POINT_CONT_4,	"Two point controller 4" },
+	{ TWO_POINT_CONT_5,	"Two point controller 5" },
+	{ TWO_POINT_CONT_6,	"Two point controller 6" },
+	{ TWO_POINT_CONT_7,	"Two point controller 7" },
+	{ TWO_POINT_CONT_8,	"Two point controller 8" },
+	{ TWO_POINT_CONT_9,	"Two point controller 9" },
+	{ TWO_POINT_CONT_10,	"Two point controller 10" },
+	{ TWO_POINT_CONT_11,	"Two point controller 11" },
+	{ TWO_POINT_CONT_12,	"Two point controller 12" },
+	{ TWO_POINT_CONT_13,	"Two point controller 13" },
+	{ TWO_POINT_CONT_14,	"Two point controller 14" },
+	{ TWO_POINT_CONT_15,	"Two point controller 15" },
+	{ TWO_POINT_CONT_16,	"Two point controller 16" },
+	{ CURVE_CTRLR_1,	"Curve controller 1" },
+	{ CURVE_CTRLR_2,	"Curve controller 2" },
+	{ CURVE_CTRLR_3,	"Curve controller 3" },
+	{ CURVE_CTRLR_4,	"Curve controller 4" },
+	{ RGB_LED_RED,		"RGB LED red" },
+	{ RGB_LED_BLUE,		"RGB LED blue" },
+	{ RGB_LED_GREEN,	"RGB LED green" },
+	{ PRESET_VAL_1,		"Preset value 1" },
+	{ PRESET_VAL_2,		"Preset value 2" },
+	{ PRESET_VAL_3,		"Preset value 3" },
+	{ PRESET_VAL_4,		"Preset value 4" },
+	{ PRESET_VAL_5,		"Preset value 5" },
+	{ PRESET_VAL_6,		"Preset value 6" },
+	{ PRESET_VAL_7,		"Preset value 7" },
+	{ PRESET_VAL_8,		"Preset value 8" },
+	{ PRESET_VAL_9,		"Preset value 9" },
+	{ PRESET_VAL_10,	"Preset value 10" },
+	{ PRESET_VAL_11,	"Preset value 11" },
+	{ PRESET_VAL_12,	"Preset value 12" },
+	{ PRESET_VAL_13,	"Preset value 13" },
+	{ PRESET_VAL_14,	"Preset value 14" },
+	{ PRESET_VAL_15,	"Preset value 15" },
+	{ PRESET_VAL_16,	"Preset value 16" },
+	{ PRESET_VAL_17,	"Preset value 17" },
+	{ PRESET_VAL_18,	"Preset value 18" },
+	{ PRESET_VAL_19,	"Preset value 19" },
+	{ PRESET_VAL_20,	"Preset value 20" },
+	{ PRESET_VAL_21,	"Preset value 21" },
+	{ PRESET_VAL_22,	"Preset value 22" },
+	{ PRESET_VAL_23,	"Preset value 23" },
+	{ PRESET_VAL_24,	"Preset value 24" },
+	{ PRESET_VAL_25,	"Preset value 25" },
+	{ PRESET_VAL_26,	"Preset value 26" },
+	{ PRESET_VAL_27,	"Preset value 27" },
+	{ PRESET_VAL_28,	"Preset value 28" },
+	{ PRESET_VAL_29,	"Preset value 29" },
+	{ PRESET_VAL_30,	"Preset value 30" },
+	{ PRESET_VAL_31,	"Preset value 31" },
+	{ PRESET_VAL_32,	"Preset value 32" },
+	{ -1,			"Unknown data source" }
+};
+
+
 /* helper functions */
 
 inline int aq5_get_int(unsigned char *buffer, short offset)

--- a/src/libaquaero5.c
+++ b/src/libaquaero5.c
@@ -181,18 +181,6 @@ char *aq5_strcat(char *str1, char *str2)
 	return ret;
 }
 
-char *aq5_get_fan_data_source_string(int id) 
-{
-	int i;
-	/* We have to search for it */
-	for (i=0; fan_data_source_strings[i].val != -1; i++) {
-		if (id == fan_data_source_strings[i].val) {
-			break;
-		}
-	}
-	return (fan_data_source_strings[i].source_str);
-}
-
 int aq5_open(char *device, char **err_msg)
 {
 	struct hiddev_devinfo dinfo;
@@ -501,3 +489,17 @@ int	libaquaero5_dump_settings(char *file)
 
 	return 0;
 }
+
+
+char *libaquaero5_get_fan_data_source_string(int id) 
+{
+	int i;
+	/* We have to search for it */
+	for (i=0; fan_data_source_strings[i].val != -1; i++) {
+		if (id == fan_data_source_strings[i].val) {
+			break;
+		}
+	}
+	return (fan_data_source_strings[i].source_str);
+}
+

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -60,7 +60,7 @@ typedef enum {
 	M_RPM 		= 0x0001 
 } fan_regulation_mode_t;
 
-typedef enum { TRUE, FALSE } boolean_t;
+typedef enum { FALSE, TRUE } boolean_t;
 
 typedef enum {
 	NONE		=	0xffff,
@@ -159,6 +159,7 @@ typedef struct {
 int		libaquaero5_poll(char *device, aq5_data_t *data_dest, char **err_msg);
 int		libaquaero5_getsettings(char *device, aq5_settings_t *settings_dest, char **err_msg);
 void	libaquaero5_exit();
+char	*aq5_get_fan_data_source_string(int id);
 
 /* helpful for debugging */
 int 	libaquaero5_dump_data(char *file);

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -159,13 +159,13 @@ typedef struct {
 
 
 /* functions to be called from application */
-int		libaquaero5_poll(char *device, aq5_data_t *data_dest, char **err_msg);
-int		libaquaero5_getsettings(char *device, aq5_settings_t *settings_dest, char **err_msg);
+int	libaquaero5_poll(char *device, aq5_data_t *data_dest, char **err_msg);
+int	libaquaero5_getsettings(char *device, aq5_settings_t *settings_dest, char **err_msg);
 void	libaquaero5_exit();
-char	*aq5_get_fan_data_source_string(int id);
+char	*libaquaero5_get_fan_data_source_string(int id);
 
 /* helpful for debugging */
 int 	libaquaero5_dump_data(char *file);
-int		libaquaero5_dump_settings(char *file);
+int	libaquaero5_dump_settings(char *file);
 
 #endif /* LIBAQUAERO5_H_ */

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -142,6 +142,9 @@ typedef struct {
 } aq5_fan_control_mode_t;
 
 typedef struct {
+	double		temp_offset[AQ5_NUM_TEMP];
+	double		fan_vrm_temp_offset[AQ5_NUM_TEMP];
+	double		cpu_temp_offset[AQ5_NUM_TEMP];
 	uint16_t	fan_min_rpm[AQ5_NUM_FAN];
 	uint16_t	fan_max_rpm[AQ5_NUM_FAN];
 	double		fan_max_duty_cycle[AQ5_NUM_FAN];

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -131,7 +131,7 @@ typedef enum {
 	PRESET_VAL_29	=	0x007c,
 	PRESET_VAL_30	=	0x007d,
 	PRESET_VAL_31	=	0x007e,
-	PRESET_VAL_32	=	0x007f,
+	PRESET_VAL_32	=	0x007f
 } fan_data_source_t;
 
 typedef struct {
@@ -153,6 +153,7 @@ typedef struct {
 	fan_data_source_t	fan_data_source[AQ5_NUM_FAN];
 	uint16_t	fan_programmable_fuse[AQ5_NUM_FAN];
 } aq5_settings_t;
+
 
 /* functions to be called from application */
 int		libaquaero5_poll(char *device, aq5_data_t *data_dest, char **err_msg);

--- a/src/libaquaero5.h
+++ b/src/libaquaero5.h
@@ -55,6 +55,92 @@ typedef struct {
 	double		level[AQ5_NUM_LEVEL];
 } aq5_data_t;
 
+typedef enum { 
+	M_OUTPUT 	= 0x0000, 
+	M_RPM 		= 0x0001 
+} fan_regulation_mode_t;
+
+typedef enum { TRUE, FALSE } boolean_t;
+
+typedef enum {
+	NONE		=	0xffff,
+	/* Target value controllers */
+	TARGET_VAL_CONT_1	=	0x0040,
+	TARGET_VAL_CONT_2	=	0x0041,
+	TARGET_VAL_CONT_3	=	0x0042,
+	TARGET_VAL_CONT_4	=	0x0043,
+	TARGET_VAL_CONT_5	=	0x0044,
+	TARGET_VAL_CONT_6	=	0x0045,
+	TARGET_VAL_CONT_7	=	0x0046,
+	TARGET_VAL_CONT_8	=	0x0047,
+	/* Two point controllers */
+	TWO_POINT_CONT_1	=	0x0048,
+	TWO_POINT_CONT_2	=	0x0049,
+	TWO_POINT_CONT_3	=	0x004a,
+	TWO_POINT_CONT_4	=	0x004b,
+	TWO_POINT_CONT_5	=	0x004c,
+	TWO_POINT_CONT_6	=	0x004d,
+	TWO_POINT_CONT_7	=	0x004e,
+	TWO_POINT_CONT_8	=	0x004f,
+	TWO_POINT_CONT_9	=	0x0050,
+	TWO_POINT_CONT_10	=	0x0051,
+	TWO_POINT_CONT_11	=	0x0052,
+	TWO_POINT_CONT_12	=	0x0053,
+	TWO_POINT_CONT_13	=	0x0054,
+	TWO_POINT_CONT_14	=	0x0055,
+	TWO_POINT_CONT_15	=	0x0056,
+	TWO_POINT_CONT_16	=	0x0057,
+	/* Curve controllers */
+	CURVE_CTRLR_1	=	0x0058,
+	CURVE_CTRLR_2	=	0x0059,
+	CURVE_CTRLR_3	=	0x005a,
+	CURVE_CTRLR_4	=	0x005b,
+	/* RGB LEDs */
+	RGB_LED_RED	=	0x005c,
+	RGB_LED_BLUE	=	0x005d,
+	RGB_LED_GREEN	=	0x005e,
+	/* Preset values */
+	PRESET_VAL_1	=	0x0060,
+	PRESET_VAL_2	=	0x0061,
+	PRESET_VAL_3	=	0x0062,
+	PRESET_VAL_4	=	0x0063,
+	PRESET_VAL_5	=	0x0064,
+	PRESET_VAL_6	=	0x0065,
+	PRESET_VAL_7	=	0x0066,
+	PRESET_VAL_8	=	0x0067,
+	PRESET_VAL_9	=	0x0068,
+	PRESET_VAL_10	=	0x0069,
+	PRESET_VAL_11	=	0x006a,
+	PRESET_VAL_12	=	0x006b,
+	PRESET_VAL_13	=	0x006c,
+	PRESET_VAL_14	=	0x006d,
+	PRESET_VAL_15	=	0x006e,
+	PRESET_VAL_16	=	0x006f,
+	PRESET_VAL_17	=	0x0070,
+	PRESET_VAL_18	=	0x0071,
+	PRESET_VAL_19	=	0x0072,
+	PRESET_VAL_20	=	0x0073,
+	PRESET_VAL_21	=	0x0074,
+	PRESET_VAL_22	=	0x0075,
+	PRESET_VAL_23	=	0x0076,
+	PRESET_VAL_24	=	0x0077,
+	PRESET_VAL_25	=	0x0078,
+	PRESET_VAL_26	=	0x0079,
+	PRESET_VAL_27	=	0x007a,
+	PRESET_VAL_28	=	0x007b,
+	PRESET_VAL_29	=	0x007c,
+	PRESET_VAL_30	=	0x007d,
+	PRESET_VAL_31	=	0x007e,
+	PRESET_VAL_32	=	0x007f,
+} fan_data_source_t;
+
+typedef struct {
+	fan_regulation_mode_t	fan_regulation_mode;
+	boolean_t	use_startboost;
+	boolean_t	hold_minimum_power;
+	boolean_t	use_programmable_fuse;
+} aq5_fan_control_mode_t;
+
 typedef struct {
 	uint16_t	fan_min_rpm[AQ5_NUM_FAN];
 	uint16_t	fan_max_rpm[AQ5_NUM_FAN];
@@ -63,11 +149,10 @@ typedef struct {
 	double		fan_startboost_duty_cycle[AQ5_NUM_FAN];
 	uint16_t	fan_startboost_duration[AQ5_NUM_FAN];
 	uint16_t	fan_pulses_per_revolution[AQ5_NUM_FAN];
-	/* unknown 1 */
-	/* unknown 2 */
+	aq5_fan_control_mode_t	fan_control_mode[AQ5_NUM_FAN];
+	fan_data_source_t	fan_data_source[AQ5_NUM_FAN];
 	uint16_t	fan_programmable_fuse[AQ5_NUM_FAN];
 } aq5_settings_t;
-
 
 /* functions to be called from application */
 int		libaquaero5_poll(char *device, aq5_data_t *data_dest, char **err_msg);


### PR DESCRIPTION
I manged to decode those two unknown values in the fan settings data in feature report 0xB:
- Fan data source
- Fan control mode

The code isn't quite as elegant as I would like, but does seem to work. 

I also found and added support for the temperature sensor offsets in settings.
